### PR TITLE
Fix memory leak for strings passed to TVP

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -873,8 +873,6 @@ static PyObject* execute(Cursor* cur, PyObject* pSql, PyObject* params, bool ski
                         Py_XDECREF(prevParam->pObject);
                         newParam.BufferLength = newParam.StrLen_or_Ind;
                         newParam.StrLen_or_Ind = SQL_DATA_AT_EXEC;
-                        Py_INCREF(cell);
-                        newParam.pObject = cell;
                         *prevParam = newParam;
                         if(prevParam->ParameterValuePtr == &newParam.Data)
                         {


### PR DESCRIPTION
Note, while this fixes the bulk of the issue I think it might still be leaking any objects allocated for the last tuple in the sequence.

Fixes #1338